### PR TITLE
fix: resolve kindling init --build failures and wire make all to CLI install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/kindling-sh/kindling"
 LABEL org.opencontainers.image.description="Kindling operator – local Kubernetes dev environments"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 .PHONY: all
-all: build
+all: build cli
+	install -m 755 bin/kindling /opt/homebrew/bin/kindling
 
 ##@ General
 
@@ -80,8 +81,12 @@ build: manifests generate fmt vet ## Build manager binary.
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
+.PHONY: ui
+ui: ## Build the dashboard UI (required before building the CLI).
+	cd cli/cmd/dashboard-ui && npm ci --silent && npm run build
+
 .PHONY: cli
-cli: ## Build the kindling CLI binary.
+cli: ui ## Build the kindling CLI binary.
 	cd cli && go build -ldflags "-s -w -X github.com/jeffvincent/kindling/cli/cmd.Version=$(VERSION)" -o ../bin/kindling .
 	@echo "✅ bin/kindling $(VERSION) built — run: ./bin/kindling --help"
 

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -147,6 +148,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// ── Get the operator image ───────────────────────────────────
 	imgTag := "controller:latest"
+	platform := fmt.Sprintf("linux/%s", runtime.GOARCH)
 
 	if buildOperator {
 		// Build from source — requires Go, Make, and the project checkout
@@ -167,8 +169,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 		// Pull the pre-built image from GHCR
 		header("Pulling kindling operator image")
 
-		step("⬇️ ", fmt.Sprintf("docker pull %s", operatorImage))
-		if err := run("docker", "pull", operatorImage); err != nil {
+		step("⬇️ ", fmt.Sprintf("docker pull --platform %s %s", platform, operatorImage))
+		if err := run("docker", "pull", "--platform", platform, operatorImage); err != nil {
 			return fmt.Errorf("failed to pull operator image %s: %w\n\nTo build from source instead, run: kindling init --build", operatorImage, err)
 		}
 
@@ -187,11 +189,19 @@ func runInit(cmd *cobra.Command, args []string) error {
 	success("Image loaded")
 
 	// ── Load kube-rbac-proxy sidecar into Kind ──────────────────
-	rbacProxyImg := "registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0"
+	// `docker pull` + `kind load docker-image` fails on Docker Desktop's
+	// containerd image store: docker save emits the full multi-platform
+	// manifest list, and `ctr import --all-platforms` then errors because
+	// only the local platform's blobs are present locally. Building a new
+	// image from a one-line Dockerfile forces a single-platform manifest
+	// into the local store, which kind can import cleanly.
+	rbacProxyImg := "quay.io/brancz/kube-rbac-proxy:v0.18.1"
+	rbacProxyLocal := "kube-rbac-proxy-kindling:v0.18.1"
 	step("📦", "Loading kube-rbac-proxy sidecar image")
-	if err := run("docker", "pull", rbacProxyImg); err != nil {
-		warn("Failed to pull kube-rbac-proxy image — operator may not start")
-	} else if err := run("kind", "load", "docker-image", rbacProxyImg, "--name", clusterName); err != nil {
+	if err := runStdin("FROM "+rbacProxyImg+"\n", "docker", "build",
+		"--platform", platform, "-t", rbacProxyLocal, "-"); err != nil {
+		warn("Failed to build single-platform kube-rbac-proxy image — operator may not start")
+	} else if err := run("kind", "load", "docker-image", rbacProxyLocal, "--name", clusterName); err != nil {
 		warn("Failed to load kube-rbac-proxy into Kind")
 	} else {
 		success("kube-rbac-proxy sidecar loaded")

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -26,11 +26,11 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,7 +1,7 @@
-resources:
-- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+- manager.yaml
 images:
 - name: controller
   newName: controller


### PR DESCRIPTION
## Summary

- **Makefile**: `make all` now builds both operator and CLI, adds `ui` target for dashboard (required for the embedded dashboard), and installs `bin/kindling` to `/opt/homebrew/bin/kindling` so `kindling` is immediately on PATH
- **cli/cmd/init.go**: fix kube-rbac-proxy Kind load — `docker pull` + `kind load docker-image` fails on Docker Desktop's containerd store because `docker save` emits the full multi-platform manifest list and `ctr import --all-platforms` errors when only local-platform blobs are present; fix is to build a fresh single-platform image via a one-line `docker build` from stdin; also updates rbac proxy to `quay.io/brancz/kube-rbac-proxy:v0.18.1` to align with CI
- **config/default/manager_auth_proxy_patch.yaml**: update kube-rbac-proxy image to match CI (`quay.io/brancz/kube-rbac-proxy:v0.18.1`)
- **config/default/kustomization.yaml**: replace deprecated `patchesStrategicMerge` with `patches` (removed in kustomize v5)
- **config/manager/kustomization.yaml**: move `apiVersion`/`kind` before `resources` (required field ordering)
- **Dockerfile**: fix `FROM ... as builder` → `FROM ... AS builder` casing mismatch

## Test plan

- [x] `make all` builds clean and installs `kindling` to `/opt/homebrew/bin/kindling`
- [x] `kindling init --build` completes with `🎉 kindling is ready!` and no warnings
- [x] `kustomize build config/crd` and `kustomize build config/default` both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)