### PR TITLE
Fix prod ingress deploy reliability + dashboard external IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,18 @@ kindling-snapshot/
 
 # kindling secrets (do not commit)
 .kindling/secrets.yaml
+
+# Agentic coding-assistant context files — deliberately removed from the repo
+# (see "remove sloppy agentic context files") and regenerated locally by
+# `kindling intel`. Never commit these back.
+.github/copilot-instructions.md
+CLAUDE.md
+CONTEXT.md
+TODO.md
+.cursor/
+.windsurfrules
+cli/.github/copilot-instructions.md
+cli/CLAUDE.md
+cli/.cursor/
+cli/.windsurfrules
+

--- a/cli/cmd/dashboard-ui/src/pages/ProductionDeployPage.tsx
+++ b/cli/cmd/dashboard-ui/src/pages/ProductionDeployPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { fetchSnapshotStatus, fetchSnapshotCredentials, streamSnapshotDeploy, updateProdSecrets } from '../api';
-import type { SnapshotStatus, SnapshotService } from '../types';
+import { fetchSnapshotStatus, fetchSnapshotCredentials, streamSnapshotDeploy, updateProdSecrets, fetchProdIngressController } from '../api';
+import type { SnapshotStatus, SnapshotService, IngressControllerInfo } from '../types';
 import type { SnapshotCredential } from '../api';
 import { StatusBadge, EmptyState } from './shared';
 
@@ -35,6 +35,11 @@ export function ProductionDeployPage() {
   const [postDeploySecretValues, setPostDeploySecretValues] = useState<Record<string, string>>({});
   const [secretUpdateStatus, setSecretUpdateStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [secretUpdateMsg, setSecretUpdateMsg] = useState('');
+
+  // Post-deploy external IP lookup — the ingress controller's cloud LB
+  // can take a minute or two to provision, so poll until it shows up.
+  const [ingressInfo, setIngressInfo] = useState<IngressControllerInfo | null>(null);
+  const [ingressLookupFailed, setIngressLookupFailed] = useState(false);
 
   useEffect(() => {
     Promise.all([
@@ -71,6 +76,36 @@ export function ProductionDeployPage() {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [logs]);
 
+  // Once the deploy finishes successfully, look up the ingress controller's
+  // external address so the user can point DNS at it right away. Poll for
+  // a couple of minutes in case a cloud load balancer is still provisioning.
+  useEffect(() => {
+    if (step !== 'done' || logs.some(l => l.type === 'error')) return;
+    let cancelled = false;
+    let attempts = 0;
+    setIngressLookupFailed(false);
+
+    const poll = () => {
+      fetchProdIngressController()
+        .then(info => {
+          if (cancelled) return;
+          setIngressInfo(info);
+          attempts += 1;
+          if (!info.external_ip && attempts < 24) {
+            setTimeout(poll, 5000);
+          } else if (!info.external_ip) {
+            setIngressLookupFailed(true);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setIngressLookupFailed(true);
+        });
+    };
+    poll();
+
+    return () => { cancelled = true; };
+  }, [step, logs]);
+
   function toggleIngress(name: string) {
     setSelectedIngress(prev => {
       const next = new Set(prev);
@@ -84,6 +119,8 @@ export function ProductionDeployPage() {
     if (!registry) return;
     setStep('deploying');
     setLogs([]);
+    setIngressInfo(null);
+    setIngressLookupFailed(false);
 
     // Build credentials map — only include non-empty values
     const credentials: Record<string, string> = {};
@@ -111,6 +148,8 @@ export function ProductionDeployPage() {
     if (cancelRef.current) cancelRef.current();
     setStep('configure');
     setLogs([]);
+    setIngressInfo(null);
+    setIngressLookupFailed(false);
     fetchSnapshotStatus().then(s => setStatus(s)).catch(() => {});
   }
 
@@ -424,6 +463,54 @@ export function ProductionDeployPage() {
               </button>
             </div>
           )}
+        </div>
+      )}
+
+      {/* External access — the ingress controller's address for DNS/TLS setup */}
+      {step === 'done' && !logs.some(l => l.type === 'error') && (
+        <div className="card" style={{ marginTop: 16 }}>
+          <div className="card-header">
+            <span className="card-icon">🌐</span>
+            <h3>External Access</h3>
+          </div>
+          <div className="card-body">
+            {!ingressInfo?.external_ip && !ingressLookupFailed && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }} className="text-dim">
+                <span className="deploy-log-icon deploy-log-spinner">◌</span>
+                Waiting for the ingress controller's external IP (cloud load balancers can take a minute or two to provision)…
+              </div>
+            )}
+
+            {!ingressInfo?.external_ip && ingressLookupFailed && (
+              <div style={{ padding: '8px 12px', background: 'var(--bg-elevated)', borderRadius: 6, border: '1px solid var(--error-border, #cc444444)', fontSize: 13 }}>
+                ✗ Could not determine an external IP yet. Run <code>kubectl get svc -n traefik --context {status?.context}</code> from
+                the CLI, or click Refresh below once the ingress controller has an address.
+                <div style={{ marginTop: 8 }}>
+                  <button className="btn btn-secondary" onClick={() => { setIngressLookupFailed(false); fetchProdIngressController().then(setIngressInfo).catch(() => setIngressLookupFailed(true)); }}>
+                    Refresh
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {ingressInfo?.external_ip && (
+              <>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 8 }}>
+                  <span className="mono" style={{ fontSize: 16, fontWeight: 600 }}>{ingressInfo.external_ip}</span>
+                  <span className="tag" style={{ fontSize: 10 }}>load balancer</span>
+                </div>
+                <div style={{ marginBottom: 12, padding: '8px 12px', background: 'var(--bg-elevated)', borderRadius: 6, border: '1px solid var(--info-border, #4488cc44)', fontSize: 13 }}>
+                  Create a DNS A record pointing your domain at this address, then configure TLS:
+                  <pre className="prod-code-block" style={{ marginTop: 8 }}>
+{`<your-domain>  →  ${ingressInfo.external_ip}
+
+kindling production tls --context ${status?.context} \\
+  --domain <your-domain> --email <you@example.com>`}
+                  </pre>
+                </div>
+              </>
+            )}
+          </div>
         </div>
       )}
 

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -199,32 +199,56 @@ func resolveProjectDir() (string, error) {
 	}
 	cachedDir := filepath.Join(home, ".kindling")
 
+	// Pin the auto-cloned checkout to this CLI binary's own release tag.
+	// DefaultOperatorImage is pinned to the same version at release time
+	// (see .goreleaser.yml), so the operator image that gets pulled by
+	// default must be matched with CRDs/kustomize manifests from that same
+	// tag — not whatever main happens to be at, which drifts constantly on
+	// an actively developed repo and can introduce CRD/controller schema
+	// mismatches that only "--build" (which builds from the same checkout)
+	// papers over. Unreleased/dev builds (Version == "dev") have no
+	// matching tag, so they fall back to main as before.
+	ref := "main"
+	if Version != "dev" {
+		ref = "v" + Version
+	}
+
 	if _, err := os.Stat(filepath.Join(cachedDir, "kind-config.yaml")); err == nil {
-		// Already cloned — fix remote if pointing to old org, then pull latest
+		// Already cloned — fix remote if pointing to old org, then sync to
+		// the ref matching this CLI's version.
 		step("📂", fmt.Sprintf("Using cached project at %s", cachedDir))
 		remote, _ := runCapture("git", "-C", cachedDir, "remote", "get-url", "origin")
 		if strings.Contains(remote, "jeff-vincent/kindling") {
 			_ = runDir(cachedDir, "git", "remote", "set-url", "origin",
 				"https://github.com/kindling-sh/kindling.git")
 		}
-		// Unshallow if needed so ff-only pull works on grafted clones
+		// Unshallow if needed so fetching an arbitrary tag/branch works on
+		// grafted clones
 		if _, err := os.Stat(filepath.Join(cachedDir, ".git", "shallow")); err == nil {
 			_ = runDir(cachedDir, "git", "fetch", "--unshallow", "-q")
 		}
-		if err := runDir(cachedDir, "git", "pull", "--ff-only", "-q"); err != nil {
-			// ff-only failed — force reset to origin/main
-			warn("Cached ~/.kindling diverged — resetting to latest")
-			_ = runDir(cachedDir, "git", "fetch", "origin", "-q")
-			_ = runDir(cachedDir, "git", "reset", "--hard", "origin/main")
+		if err := runDir(cachedDir, "git", "fetch", "origin", ref, "-q"); err != nil {
+			warn(fmt.Sprintf("Could not fetch %s — using existing cached checkout", ref))
+		} else if err := runDir(cachedDir, "git", "checkout", "-q", "FETCH_HEAD"); err != nil {
+			warn(fmt.Sprintf("Could not check out %s — using existing cached checkout", ref))
 		}
 		return cachedDir, nil
 	}
 
 	// Clone
-	step("📥", "Cloning kindling project to ~/.kindling")
-	if err := run("git", "clone", "--depth=1",
+	step("📥", fmt.Sprintf("Cloning kindling project (%s) to ~/.kindling", ref))
+	if err := run("git", "clone", "--depth=1", "--branch", ref,
 		"https://github.com/kindling-sh/kindling.git", cachedDir); err != nil {
-		return "", fmt.Errorf("failed to clone kindling repo to %s: %w", cachedDir, err)
+		if ref == "main" {
+			return "", fmt.Errorf("failed to clone kindling repo to %s: %w", cachedDir, err)
+		}
+		// Tag might not exist yet (e.g. a release still propagating) —
+		// fall back to main so init still works, rather than hard-failing.
+		warn(fmt.Sprintf("Could not clone tag %s — falling back to main", ref))
+		if err := run("git", "clone", "--depth=1",
+			"https://github.com/kindling-sh/kindling.git", cachedDir); err != nil {
+			return "", fmt.Errorf("failed to clone kindling repo to %s: %w", cachedDir, err)
+		}
 	}
 	return cachedDir, nil
 }

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -86,6 +86,24 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("missing required tools: %v", missing)
 	}
 
+	// Optional tools for graduating a dev environment to production
+	// (`kindling snapshot -r <registry> --deploy`). Not required for local
+	// dev, so these are warnings rather than a hard failure — but flagged
+	// here, at setup time, instead of surfacing mid-deploy after the user
+	// has already read cluster state and entered registry credentials.
+	optionalTools := map[string]string{
+		"crane": "brew install crane      # pushes images to your production registry (kindling snapshot -r ...)",
+		"helm":  "brew install helm       # installs the production Helm chart (kindling snapshot --deploy)",
+	}
+	for _, tool := range []string{"crane", "helm"} {
+		if commandExists(tool) {
+			step("✓", fmt.Sprintf("%s found", tool))
+		} else {
+			warn(fmt.Sprintf("%s not found on PATH — needed later for 'kindling snapshot --deploy' (production graduation)", tool))
+			step("→", optionalTools[tool])
+		}
+	}
+
 	configPath := filepath.Join(dir, "kind-config.yaml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		return fmt.Errorf("kind-config.yaml not found in %s — are you in the kindling project root?", dir)

--- a/cli/cmd/production_ops_api.go
+++ b/cli/cmd/production_ops_api.go
@@ -199,9 +199,12 @@ func handleProdSnapshotDeploy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── Push images (shared pipeline) ──────────────────────────
-	pushSnapshotImages(dses, body.Registry, tag, userPrefix, body.RegistryUser, body.RegistryPass, func(msg string) {
+	if err := pushSnapshotImages(dses, body.Registry, tag, userPrefix, body.RegistryUser, body.RegistryPass, func(msg string) {
 		send("step", msg)
-	})
+	}); err != nil {
+		send("error", "Image push failed: "+err.Error())
+		return
+	}
 
 	// ── Generate chart (shared pipeline) ────────────────────────
 	chartName := "kindling-snapshot"

--- a/cli/cmd/snapshot.go
+++ b/cli/cmd/snapshot.go
@@ -417,6 +417,13 @@ func runSnapshot(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Fail fast on missing tools before reading cluster state or prompting
+	// for registry credentials — cheaper to catch here than deep inside
+	// the push step after the user has already typed a password.
+	if snapshotRegistry != "" && !commandExists("crane") {
+		return fmt.Errorf("crane is required for --registry (brew install crane) — run 'kindling init' to check for this and other optional tools")
+	}
+
 	header("Exporting cluster snapshot")
 
 	step("📡", "Reading DevStagingEnvironments from cluster")
@@ -475,12 +482,7 @@ func runSnapshot(cmd *cobra.Command, args []string) error {
 		}
 
 		if err := craneCopyImages(dses, snapshotRegistry, tag, userPrefix, regUser, regPass); err != nil {
-			warn(fmt.Sprintf("Could not push images: %v", err))
-			warn("Falling back to image references only (no push)")
-			// Still rewrite image refs so the chart targets the right registry
-			for i := range dses {
-				dses[i].Image = registryImage(dses[i].Name, snapshotRegistry, tag)
-			}
+			return fmt.Errorf("image push failed: %w", err)
 		}
 	}
 
@@ -1878,18 +1880,20 @@ func craneCopyImages(dses []snapshotDSE, registry, tag, userPrefix, regUser, reg
 		if !pushed {
 			warn(fmt.Sprintf("Could not push %s — not in registry or Docker daemon", dses[i].Name))
 			failed = append(failed, dses[i].Name)
+			// Do NOT rewrite the image ref on failure — leaving it pointed
+			// at the production destination tag would make the deploy
+			// silently reuse whatever image already happens to exist there
+			// (stale or wrong-arch), instead of surfacing the failure.
+			continue
 		}
 
-		// Always rewrite image ref to target the production registry
+		// Only rewrite the image ref once the push has actually succeeded.
 		dses[i].Image = dst
 	}
 
-	if len(failed) == len(seen) {
-		return fmt.Errorf("all image pushes failed — check registry credentials and source images")
-	}
 	if len(failed) > 0 {
-		warn(fmt.Sprintf("%d/%d images could not be pushed: %s",
-			len(failed), len(seen), strings.Join(failed, ", ")))
+		return fmt.Errorf("%d/%d image(s) could not be pushed: %s — refusing to deploy, since the destination tag(s) may already reference a stale or wrong-architecture image",
+			len(failed), len(seen), strings.Join(failed, ", "))
 	}
 
 	success("Images pushed to registry")

--- a/cli/cmd/snapshot_core.go
+++ b/cli/cmd/snapshot_core.go
@@ -43,28 +43,24 @@ func stripDSEPrefix(dses []snapshotDSE) string {
 
 // pushSnapshotImages pushes images from the local Kind cluster to a
 // remote registry via crane/docker, then rewrites dse[i].Image to
-// point at the destination. On total failure the image refs are still
-// rewritten so the generated chart references the correct registry.
+// point at the destination. If any image fails to push, it returns an
+// error instead of silently leaving the chart pointed at whatever
+// image already happens to exist at the destination tag.
 //
 // progress is an optional callback for streaming status messages.
-func pushSnapshotImages(dses []snapshotDSE, registry, tag, userPrefix, regUser, regPass string, progress func(string)) {
+func pushSnapshotImages(dses []snapshotDSE, registry, tag, userPrefix, regUser, regPass string, progress func(string)) error {
 	if progress == nil {
 		progress = func(string) {}
 	}
 
 	progress(fmt.Sprintf("Pushing images to %s (tag: %s)", registry, tag))
 
-	err := craneCopyImages(dses, registry, tag, userPrefix, regUser, regPass)
-	if err != nil {
-		progress(fmt.Sprintf("Image push encountered errors: %v — falling back to ref-only rewrite", err))
-		// Fallback: rewrite image refs so the chart targets the right
-		// registry even though the push didn't succeed for everything.
-		for i := range dses {
-			dses[i].Image = registryImage(dses[i].Name, registry, tag)
-		}
-	} else {
-		progress("Images pushed to registry")
+	if err := craneCopyImages(dses, registry, tag, userPrefix, regUser, regPass); err != nil {
+		return err
 	}
+
+	progress("Images pushed to registry")
+	return nil
 }
 
 // ── 3. Export chart ─────────────────────────────────────────────

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -307,33 +307,60 @@ Override with: `make docker-build IMG=myregistry/kindling:v1.0.0`
 
 ## Release process
 
-### Version bump
+Releases are fully automated by GoReleaser (`.goreleaser.yml`) and the
+`release` GitHub Actions workflow (`.github/workflows/release.yml`) — there
+is no manual version bump in source. `Version` and the default operator
+image tag (`DefaultOperatorImage`) are both injected via ldflags from the
+git tag at release time (see the `builds.ldflags` section of
+`.goreleaser.yml`).
 
-1. Update `version` in `cli/cmd/version.go`
-2. Update `CHANGELOG.md`
-3. Run tests: `make test`
-4. Build: `make cli`
-5. Tag: `git tag v0.9.0`
-6. Push: `git push origin v0.9.0`
+`main` is protected — direct pushes/merges are blocked. Releases always go
+**PR → merge → tag → push tag**, in that order. Tagging before the merge
+would ship a release from a commit that was never actually reviewed onto
+`main`, and — since `resolveProjectDir`'s `~/.kindling` auto-clone is pinned
+to `v<Version>` — would check out CRDs/manifests that don't match what's on
+`main`.
 
-### Binary distribution
+1. **Open a PR** from your branch into `main`:
+   ```bash
+   git push -u origin <branch>
+   gh pr create --base main --head <branch> --title "..." --body "..."
+   ```
+2. **Wait for CI** (`ci.yml` runs on PRs to `main`) to pass, then get the PR
+   reviewed and merged on GitHub through the normal flow — branch
+   protection requires it, there's no way around it (and shouldn't be).
+3. **Tag the resulting `main` commit** with the next version (semver —
+   patch for fixes, minor for user-facing features, major for breaking
+   changes):
+   ```bash
+   git checkout main && git pull --ff-only
+   git tag v0.11.1
+   git push origin v0.11.1
+   ```
+4. Pushing the tag triggers `release.yml`, which:
+   - Builds & publishes CLI binaries for `linux`/`darwin` × `amd64`/`arm64`
+     via GoReleaser
+   - Updates the `kindling-sh/homebrew-tap` formula
+   - Builds & pushes the multi-arch (`linux/amd64,linux/arm64`) operator
+     image to `ghcr.io/kindling-sh/kindling-operator`, tagged with the
+     version, `<major>.<minor>`, `latest`, and the commit SHA
+   - Creates a GitHub Release with changelog + binaries
 
-The CLI binary is the primary distribution artifact:
+Note: git tags are independent refs — `release.yml` triggers on any `v*`
+tag push regardless of which branch contains that commit. Still, always tag
+`main` (after merging), never a feature branch, so the released version
+matches what's actually shipped.
 
+### Manual/ad-hoc operator image builds
+
+For a one-off test image (not a real release — e.g. testing an operator
+change against a prod cluster before it's merged), use the manual workflow
+instead of tagging:
 ```bash
-# Build for multiple platforms
-GOOS=darwin GOARCH=arm64 go build -o kindling-darwin-arm64 ./cli
-GOOS=darwin GOARCH=amd64 go build -o kindling-darwin-amd64 ./cli
-GOOS=linux GOARCH=amd64  go build -o kindling-linux-amd64  ./cli
-GOOS=linux GOARCH=arm64  go build -o kindling-linux-arm64  ./cli
+gh workflow run publish-operator.yml -f tag=edge
 ```
-
-### Operator image
-
-```bash
-make docker-build IMG=ghcr.io/jeffvincent/kindling:v0.9.0
-make docker-push  IMG=ghcr.io/jeffvincent/kindling:v0.9.0
-```
+This pushes `ghcr.io/kindling-sh/kindling-operator:edge` without touching
+CLI binaries, Homebrew, or GitHub Releases.
 
 ---
 


### PR DESCRIPTION
## Summary
- **snapshot**: per-service image push failures now abort the deploy hard instead of silently falling back to whatever image already exists at the destination tag. Root cause of a real incident where a stale, wrong-architecture (arm64) image kept running in prod because the push failure was only ever a warning.
- **init**: preflight-checks `crane`/`helm` and warns with install instructions, instead of surfacing the failure mid-deploy after the user has already entered registry credentials.
- **snapshot**: fails fast if `crane` is missing, before prompting for registry credentials.
- **helpers**: `~/.kindling` auto-clone is now pinned to the CLI binary's own release tag (`v<Version>`) instead of tracking `main`, so CRDs/kustomize manifests never drift ahead of the pinned operator image (was causing `kindling init` to need `--build` to work around a version-skew bug).
- **dashboard**: shows the ingress controller's external IP + DNS/TLS next steps right after a successful production deploy.
- **gitignore**: excludes `kindling intel`'s agentic context files (already removed from `main` in a prior cleanup; these regenerate locally and must not be recommitted).

## Testing
- `go build/vet/test ./...` (cli module) — all green
- `npm run build` (dashboard-ui) — clean
- Verified end-to-end against a real DigitalOcean prod cluster: reproduced the stale-image incident, fixed root cause, redeployed successfully with all services healthy.