### PR TITLE
Fix kindling init: stale ~/.kindling clone + operator image load failure

### DIFF
--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -236,6 +236,21 @@ func resolveProjectDir() (string, error) {
 	}
 
 	// Clone
+	//
+	// At this point cachedDir doesn't contain a valid checkout (the
+	// "already cloned" branch above already returned if it did) — but it
+	// may still exist as a stale/incomplete directory (e.g. left over from
+	// an older kindling version's clone layout, a previous interrupted
+	// clone, or unrelated leftover files). `git clone` refuses to write
+	// into a non-empty directory, so wipe it first rather than failing
+	// with a confusing "destination path already exists" error.
+	if info, statErr := os.Stat(cachedDir); statErr == nil && info.IsDir() {
+		warn(fmt.Sprintf("%s exists but isn't a valid checkout — recreating it", cachedDir))
+		if err := os.RemoveAll(cachedDir); err != nil {
+			return "", fmt.Errorf("cannot remove stale %s: %w", cachedDir, err)
+		}
+	}
+
 	step("📥", fmt.Sprintf("Cloning kindling project (%s) to ~/.kindling", ref))
 	if err := run("git", "clone", "--depth=1", "--branch", ref,
 		"https://github.com/kindling-sh/kindling.git", cachedDir); err != nil {
@@ -245,6 +260,11 @@ func resolveProjectDir() (string, error) {
 		// Tag might not exist yet (e.g. a release still propagating) —
 		// fall back to main so init still works, rather than hard-failing.
 		warn(fmt.Sprintf("Could not clone tag %s — falling back to main", ref))
+		// The failed attempt above may have left a partial directory
+		// behind (git creates the destination before it starts
+		// networking) — remove it so the retry doesn't hit the same
+		// "already exists" error regardless of the real failure cause.
+		_ = os.RemoveAll(cachedDir)
 		if err := run("git", "clone", "--depth=1",
 			"https://github.com/kindling-sh/kindling.git", cachedDir); err != nil {
 			return "", fmt.Errorf("failed to clone kindling repo to %s: %w", cachedDir, err)

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -192,9 +192,17 @@ func runInit(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to pull operator image %s: %w\n\nTo build from source instead, run: kindling init --build", operatorImage, err)
 		}
 
-		// Tag as controller:latest so kustomize config works as-is
-		if err := run("docker", "tag", operatorImage, imgTag); err != nil {
-			return fmt.Errorf("failed to tag operator image: %w", err)
+		// Re-package as a single-platform image before tagging. On Docker
+		// Desktop's containerd image store, `docker pull --platform X`
+		// still leaves the local tag referencing the full multi-platform
+		// manifest list; `kind load docker-image` (docker save + ctr
+		// import) then fails with "content digest ... not found" because
+		// only the requested platform's blobs are present locally.
+		// Building a new image from a one-line Dockerfile forces a real
+		// single-platform manifest into the local store, which kind can
+		// import cleanly (same fix used for kube-rbac-proxy below).
+		if err := buildSinglePlatformImage(operatorImage, platform, imgTag); err != nil {
+			return fmt.Errorf("failed to create single-platform operator image: %w", err)
 		}
 		success(fmt.Sprintf("Operator image ready (%s)", operatorImage))
 	}
@@ -216,8 +224,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	rbacProxyImg := "quay.io/brancz/kube-rbac-proxy:v0.18.1"
 	rbacProxyLocal := "kube-rbac-proxy-kindling:v0.18.1"
 	step("📦", "Loading kube-rbac-proxy sidecar image")
-	if err := runStdin("FROM "+rbacProxyImg+"\n", "docker", "build",
-		"--platform", platform, "-t", rbacProxyLocal, "-"); err != nil {
+	if err := buildSinglePlatformImage(rbacProxyImg, platform, rbacProxyLocal); err != nil {
 		warn("Failed to build single-platform kube-rbac-proxy image — operator may not start")
 	} else if err := run("kind", "load", "docker-image", rbacProxyLocal, "--name", clusterName); err != nil {
 		warn("Failed to load kube-rbac-proxy into Kind")
@@ -288,4 +295,21 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// buildSinglePlatformImage re-packages a pulled image as a single-platform
+// image tagged localTag, by building a one-line "FROM <srcImage>" Dockerfile
+// for the given platform.
+//
+// This works around a Docker Desktop containerd-image-store issue: even
+// after `docker pull --platform X <srcImage>`, the local tag can still
+// reference the full multi-platform manifest list. `kind load docker-image`
+// (which does `docker save` + `ctr import`) then fails with
+// "content digest ... not found" because only the requested platform's
+// blobs are actually present locally. Building a new image forces Docker to
+// materialize a real single-platform manifest, which kind can import
+// cleanly.
+func buildSinglePlatformImage(srcImage, platform, localTag string) error {
+	return runStdin("FROM "+srcImage+"\n", "docker", "build",
+		"--platform", platform, "-t", localTag, "-")
 }


### PR DESCRIPTION
## Summary
Two real bugs found while testing v0.11.1 on a fresh Homebrew install:

1. **`kind load docker-image` failing on the operator image** with:
   ```
   ctr: content digest sha256:...: not found
   Error: failed to load image into Kind: exit status 1
   ```
   Root cause: on Docker Desktop's containerd image store, `docker pull --platform X <image>` can leave the local tag referencing the full multi-platform manifest list rather than a real single-platform image. `kind load docker-image` (which does `docker save` + `ctr import`) then fails because only the requested platform's blobs are actually present locally. This exact issue was already known and worked around for the `kube-rbac-proxy` sidecar (see the comment above it), but the same workaround wasn't applied to the main operator image pull path. Fixed by extracting `buildSinglePlatformImage()` and using it for both.

2. **`~/.kindling` auto-clone failing** with:
   ```
   fatal: destination path '/Users/.../\.kindling' already exists and is not an empty directory.
   ```
   `resolveProjectDir()` only recognized a cached checkout via `kind-config.yaml`'s presence; if `~/.kindling` existed but wasn't a valid checkout (stale directory, leftover from an older kindling version, or debris from a previously-interrupted clone), `git clone` would refuse to write into it — and since the code retries with a `main` fallback on tag-clone failure, the *retry* would hit the exact same error, masking the real problem. Now wipes a stale/invalid `~/.kindling` before cloning, and also cleans up after a failed first attempt before retrying.

## Testing
`go build/vet/test ./...` — all green.